### PR TITLE
Removing the slot for submit button in favor of input inside default slot

### DIFF
--- a/app-react/src/App.js
+++ b/app-react/src/App.js
@@ -22,9 +22,7 @@ function App() {
             <input type="text" name="reaction" />
           </label>
           <br />
-          <slot slot="submit">
-            <input type="submit" value="What's your reaction?" />
-          </slot>
+          <input type="submit" value="What's your reaction?" />
         </ds-form>
       </ds-hero>
       <span slot="footer">

--- a/app-stencil/src/components/app-root/app-root.tsx
+++ b/app-stencil/src/components/app-root/app-root.tsx
@@ -28,9 +28,7 @@ export class AppRoot {
               <input type="text" name="expertise" />
             </label>
             <br />
-            <slot slot="submit">
-              <input type="submit" value="Say Something" />
-            </slot>
+            <input type="submit" value="Say Something" />
           </ds-form>
         </ds-hero>
         <span slot="footer">

--- a/app-svelte/src/App.svelte
+++ b/app-svelte/src/App.svelte
@@ -15,9 +15,7 @@
 				<input type="text" name="{fieldName}" />
 			</label>
 			<br />
-			<slot slot="submit">
-				<input type="submit" value="{submitLabel}" />
-			</slot>
+			<input type="submit" value="{submitLabel}" />
 		</ds-form>
 	</ds-hero>
 	<span slot="footer">

--- a/app-vue/src/App.vue
+++ b/app-vue/src/App.vue
@@ -23,9 +23,7 @@ function handleFormData(event) {
           <input type="text" name="view" />
         </label>
         <br />
-        <slot slot="submit">
-          <input type="submit" value="Looking good?" />
-        </slot>
+        <input type="submit" value="Looking good?" />
       </ds-form>
     </ds-hero>
     <span slot="footer">

--- a/design-system/src/components/ds-form/ds-form.tsx
+++ b/design-system/src/components/ds-form/ds-form.tsx
@@ -36,7 +36,6 @@ export class DsForm {
           onClick={event => this.onClick(event)}
         >
           <slot></slot>
-          <slot name="submit"></slot>
         </form>
       </Host>
     );


### PR DESCRIPTION
## How to test

We'll want to load up each sample application that consumes the design system and check that it works.

## What it does

Removes the declaration of a `submit` slot in the design system. Instead, whatever expected content for a `ds-form` element is supposed to have an input for submission. This simplifies our demo.